### PR TITLE
Added fold for cumulative openstack data

### DIFF
--- a/lib/Vaultaire/Query.hs
+++ b/lib/Vaultaire/Query.hs
@@ -93,6 +93,12 @@ sumPoints :: Monad m => Query m SimplePoint -> Query m Word64
 sumPoints = aggregateQ (\p -> P.sum (p >-> P.map simplePayload))
 
 
+
+-- | Openstack cumulative data is from last startup.
+--   So when we process cumulative data we need to account for this.
+--   Since (excluding restarts) each point is strictly non-decreasing,
+--   we simply use a modified fold to deal with the case where the latest point
+--   is less than the second latest point (indicating a restart)
 aggregateCumulativePoints :: Monad m => Query m SimplePoint -> Query m Word64
 aggregateCumulativePoints = aggregateQ (\p -> P.fold helper (0, 0) (\(a, b) -> a + b) p)
   where


### PR DESCRIPTION
Openstack cumulative data is from last startup. So when we process cumulative data we need to account for this.

Since (excluding restarts) each point is strictly non-decreasing, we simply use a modified fold to deal with the case where the latest point is less than the second latest point (indicating a restart)
