### PR TITLE
Fixed aggregateCumulative

### DIFF
--- a/lib/Vaultaire/Query.hs
+++ b/lib/Vaultaire/Query.hs
@@ -107,12 +107,12 @@ sumPoints = aggregateQ (\p -> P.sum (p >-> P.map simplePayload))
 --   is less than the second latest point (indicating a restart)
 aggregateCumulativePoints :: Monad m => Query m SimplePoint -> m Word64
 aggregateCumulativePoints (Select points) = do
-    first <- P.head points
-    case first of
-        Nothing -> return 0
-        Just p  -> do
+    res <- next points
+    case res of
+        Left _ -> return 0
+        Right (p, points') -> do
             let v = simplePayload p
-            P.fold helper (0, v) (\(a, b) -> a + b - v) points
+            P.fold helper (0, v) (\(a, b) -> a + b - v) points'
   where
     helper (sum, last) (SimplePoint _ _ v) =
         if v < last


### PR DESCRIPTION
aggregateCumulative was originally using Pipes.Prelude.head over
Pipes.next to get the first point. Due to the monadic nature of the
data, this would cause the underlying query to be repeated and lead
to unpredicatable data. Since Pipes.next works in the same pull-based
manner as >-> and most other Pipes constructs, it is well-behaved in
line with our expectations.

Tests did not pick this up as the test data was pure.
